### PR TITLE
fix(ci): fix/chore ブランチの push CI + 削除済みブランチ残骸の整理

### DIFF
--- a/.devcontainer/allowed-domains.conf
+++ b/.devcontainer/allowed-domains.conf
@@ -21,7 +21,8 @@ playwright.download.prss.microsoft.com
 # の許可は、CF 配下に移った example.com（2026-07-18 実測）まで通してしまい自己検証と両立しない
 # ため撤回。使うホストだけドメイン解決で許可する。
 # 注意: CF のエッジ IP は多数のサイトで共有されるため、これでも完全な出口制限にはならない
-feat-phase-1-byte-lark.tanimoto-a49.workers.dev
+# ブランチ別 alias（<branch>-byte-lark....workers.dev）は下記と同じエッジ IP に解決されるため
+# 個別追加は不要（2026-08-10 実測：一覧に無い alias でも疎通した）
 byte-lark.tanimoto-a49.workers.dev
 
 # 本番ドメイン（scripts/health-check.sh の動作確認・公開後の実測用）

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,9 +1,9 @@
 name: Quality Checks
 on:
   push:
-    branches: [main, "feat/*"]
+    branches: [main, "feat/*", "fix/*", "chore/*"]
   pull_request:
-    branches: [main, "feat/*"]
+    branches: [main]
 
 # GITHUB_TOKEN を読み取り専用に固定
 permissions:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,9 +1,9 @@
 name: UI Tests
 on:
   push:
-    branches: [main, "feat/*"]
+    branches: [main, "feat/*", "fix/*", "chore/*"]
   pull_request:
-    branches: [main, "feat/*"]
+    branches: [main]
 
 # GITHUB_TOKEN を読み取り専用に固定（アーティファクトのアップロードに追加権限は不要）
 permissions:

--- a/docs/pbi/20260810-PHASE1E-001-postlaunch-housekeeping.md
+++ b/docs/pbi/20260810-PHASE1E-001-postlaunch-housekeeping.md
@@ -23,7 +23,7 @@ Status: NotStarted
 
 - [ ] **`yarn fonts` を `docs/writing-workflow.md` に書く**。記事を足すと収録字が増えるためフォントの作り直しが要る（`yarn fonts` = build → 生成 → build）。回し忘れは CI の `yarn fonts:check` が止めるが、執筆手順に書かれていないので今は CI が落ちて初めて気づく。手順のどの段階で回すか（記事を書き終えて `draft: false` にする直前）まで明記する
 - [ ] **`src/layouts/BaseLayout.astro` に `<link rel="alternate" type="application/rss+xml">` を足す**。`/rss.xml` は配信されているのに HTML から辿れず、購読ツールが自動で見つけられない。`title` は `og:site_name` と揃える。全ページに入る（RSS は 1 本しかないため）
-- [ ] **`scripts/lighthouse-audit.sh` の `BASE` 既定値を本番（`https://byte-lark.com`）に変える**。現状は preview の workers.dev で、引数なしで叩くと本番でないものを測る（PHASE1D-004 で実際に踏んだ）。preview を測りたいときは従来どおり第 1 引数で渡す
+- [x] **`scripts/lighthouse-audit.sh` の `BASE` 既定値を本番（`https://byte-lark.com`）に変える**：対応済み（2026-08-10、`fix/ci-branch-triggers` で先行実施。既定値が削除済みブランチ `feat-phase-1` の alias を指して壊れていたため、CI トリガー修正と同じ PR で処置した）
 - [ ] **`yarn check`（Biome）の対象に `worker/` `scripts/` `tests/` を足す**。現状は `src` だけで、Worker 実装・ビルドスクリプト・E2E が素通りしている。`fix` も同じ範囲に揃える。既存ファイルに指摘が出る場合は、この PBI の中で直すか `biome.json` で除外するかを判断して記録する
 - [ ] **`astro.config.mjs` の sitemap 除外フィルタから `/sample-highlight/` を外す**。そのページは PHASE1A-020 で削除済みで、存在しないパスを除外し続けている。除外が 1 件も要らなくなるなら `filter` ごと落とす
 - [ ] **`src/lib/jsonld.ts` のオリジンを `Astro.site` に追随させる**。`https://byte-lark.com` がベタ書きで、値そのものは正しいが設定と二重管理になっている。`AUTHOR.url` / `PUBLISHER.url` の 2 か所

--- a/scripts/lighthouse-audit.sh
+++ b/scripts/lighthouse-audit.sh
@@ -2,8 +2,8 @@
 # Lighthouse 監査（運営者ターミナル実行用。サンドボックス内は Chrome 起動不可 → PHASE1A-020 参照）
 #
 # 使い方:
-#   bash scripts/lighthouse-audit.sh                                  # branch alias を accessibility のみ
-#   bash scripts/lighthouse-audit.sh https://byte-lark.com            # 本番を accessibility のみ
+#   bash scripts/lighthouse-audit.sh                                  # 本番を accessibility のみ
+#   bash scripts/lighthouse-audit.sh https://<branch-alias>.workers.dev   # preview を accessibility のみ
 #   bash scripts/lighthouse-audit.sh https://byte-lark.com performance,accessibility,best-practices,seo
 #
 # devcontainer 内から回すときは Chrome のサンドボックスが使えないので、
@@ -17,7 +17,7 @@
 # lighthouse を一時ディレクトリへ npm install して直接実行するため、この罠が発生しない。
 set -u
 
-BASE="${1:-https://feat-phase-1-byte-lark.tanimoto-a49.workers.dev}"
+BASE="${1:-https://byte-lark.com}"
 CATEGORIES="${2:-accessibility}"
 # 公開記事も監査対象に含める（PHASE1C-011）。記事ページは一覧と DOM 構造が違い、
 # 見出し階層・コントラストの当たり方も別物になるため、静的 8 ページだけでは裏取りにならない


### PR DESCRIPTION
## 変更内容

### CI トリガー修正（quality.yml / ui-tests.yml）
- push トリガーを `[main, "feat/*"]` → `[main, "feat/*", "fix/*", "chore/*"]` に拡張。README §10.2 の命名規則（feat/fix/chore）に対し、fix/* chore/* への push で CI が走らず §7 の ci-status.sh 検証が PR 作成まで詰まる穴を塞ぐ
- pull_request 側は `[main]` に整理（この条件は PR の宛先ブランチ照合。PR は常に main 宛）

### 削除済みブランチ `feat/phase-1` を指す残骸の整理
- `scripts/lighthouse-audit.sh` の BASE 既定値を本番 `https://byte-lark.com` に変更（PHASE1E-001 の 3 番目を先行実施、PBI に記録済み）
- `.devcontainer/allowed-domains.conf` から同 alias 行を削除（ブランチ別 alias は共通エッジ IP に解決されるため個別許可不要、実測済み）

## 検証
- 本ブランチ（fix/*）への push だけで CI が起動 = トリガー修正の実地証明
- Quality Checks / UI Tests / Workers Builds すべて success（ed72ae1）
- UI/フロントエンド変更なし（src/ 等は非接触）→ スクショ確認 N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYLdXrATz4feodYp6JqiJa