### PR TITLE
chore(pbi): PHASE1E-003 / 004 起票（記事 T9 + トップ title/OG 画像）

### DIFF
--- a/docs/pbi/20260813-PHASE1E-003-post-devcontainer-claude-code.md
+++ b/docs/pbi/20260813-PHASE1E-003-post-devcontainer-claude-code.md
@@ -1,0 +1,38 @@
+# 訪問者は「devcontainer で Claude Code を自走させる環境を作った話」（tech）を読める
+
+Status: NotStarted
+
+## 誰が
+- 訪問者
+
+## 何をできる
+- Claude Code をコンテナ内で全権限自走させる環境（PHASE1B-016）の設計・構築・運用でぶつかった問題と解き方を、一次体験として読める
+
+## なんのために
+- 記事バックログ T9（開発環境 3 連作の 2 本目）。T1 記事（サイト構築総括）で軽く触れた devcontainer の話の本編。公開記事を 3 → 4 本に増やす（Phase 1e の主活動。カテゴリ別一覧 FR-19 は 10 本到達がトリガー）
+- 関連: docs/article-backlog.md T9 / docs/devcontainer-plan.md / PHASE1B-016 / docs/writing-workflow.md
+
+## 受け入れ条件
+- [ ] 運営者 + Claude でヒアリング（writing-workflow §3）→ Claude が Markdown ドラフト生成（`yarn new-post --slug claude-code-devcontainer --category tech`、`draft: true`。slug は着手時に運営者確認）
+- [ ] frontmatter 完備：title（`| byte-lark.com` サフィックス無し）/ description（80-120字・OGP 兼用）/ category: tech / tags / publishedAt（公開当日の日付に更新してからマージ）/ slug。本文冒頭に `# タイトル` を重複させない
+- [ ] バックログ T9 のハマりどころ 3 件を本文の柱に含める：① コンテナ内 Claude だけ URL がリンクにならない（`TERM_PROGRAM` 不在 → `--remote-env FORCE_HYPERLINK=1`）② スクショをコンテナに渡せない（CleanShot 保存先を read-only bind mount。素材: `docs/article-interviews/20260809-cleanshot-container-mount.md`）③ 母艦とコンテナの見分けがつかない（statusline に CONTAINER バッジ。「直したのに反映されない」= postCreate コピーと named volume の話、`ccdsh` 追加まで）
+- [ ] 運営者がリライトし `draft: false` に変更（最終承認を実装ログに記録）
+- [ ] `draft: false` の直前に `yarn fonts` でフォントを作り直す（writing-workflow 8 段構成、PHASE1E-001）
+- [ ] OGP / Article JSON-LD が記事ページで正しく出力される（`buildArticleJsonLd()`、headline 汚染なし）
+- [ ] `yarn build` 成功 / `yarn check:ts` エラーなし
+- [ ] ローカル スクショ確認（desktop + mobile）（CLAUDE.md §7）
+- [ ] CF preview スクショ確認（branch alias URL）（CLAUDE.md §7）
+- [ ] E2E / CI green 確認（push 後 `scripts/ci-status.sh` で UI Tests=success）（CLAUDE.md §7）
+
+## 技術メモ
+- 想定セッション数: 1（ヒアリング → ドラフト → 運営者リライト。リライト待ちは実装フェーズ外）
+- カテゴリ: tech / 想定 slug: claude-code-devcontainer
+- 一次情報: `docs/devcontainer-plan.md`（設計・手順）、PHASE1B-016 実装ログ、`.devcontainer/` 実物、`docs/article-interviews/20260809-cleanshot-container-mount.md`（gitignore 対象・経緯素材）
+- 連作の位置づけ: T8（ghostty + herdr 乗り換え）→ **T9（本 PBI）** → T10（herdr サイドバー連携）。順序が前後するので、T8 側で持つ予定だった詳細（T12 の入力ソース問題）への言及は本記事では深追いしない
+- cover 画像は cover-image skill（tools/imagegen）で生成可
+- ヒアリング内容は `docs/article-interviews/` に集約（セッション跨ぎ対策、gitignore 対象）
+
+## 備考
+- 記事バックログ T9 の正式化（docs/article-backlog.md）。起票と同時に PHASE1E-004（トップ title / OG 画像）も起票しており、本記事の運営者リライト待ちの間に 004 を進める想定（1 ツリー 1 セッションのため同時進行は逐次）
+
+## 実装ログ

--- a/docs/pbi/20260813-PHASE1E-004-home-title-og-image.md
+++ b/docs/pbi/20260813-PHASE1E-004-home-title-og-image.md
@@ -1,0 +1,40 @@
+# 検索結果と SNS カードで、トップページが「誰の何のサイトか」を名前・役割入りタイトルと専用 OG 画像で伝えられる
+
+Status: NotStarted
+
+## 誰が
+- 検索・SNS 経由の訪問者（ペルソナ最上位: エージェント担当者 / クライアント案件 PM の面談前リサーチ）
+
+## 何をできる
+- 検索結果・ブラウザタブ・SNS カードで、トップページのタイトルから運営者の名前と役割が読み取れる
+- トップページの URL をシェアしたとき、汎用のデフォルト画像ではなくサイト専用の OG 画像が出る
+
+## なんのために
+- 現状、トップの `<title>` / `og:title` は `byte-lark.com` のみ（`src/pages/index.astro:31`）。記事ページは適切なタイトルが付いており、トップだけの取りこぼし。site-plan §2 目的 1「職能リファレンス（面談時の URL 提示用）」に対し、提示された URL の第一印象で誰のサイトか分からないのは目的と直結する欠け
+- トップの og:image はフォールバックの `og-default.png`（`src/layouts/BaseLayout.astro:20-22`）。専用画像に差し替えてカードの見た目を記事と同水準にする
+- 出所: 2026-08-13 の外部レビュー指摘 T1 / T2（採用判断の経緯は INDEX.md 起票済み節）
+
+## 受け入れ条件
+- [ ] `index.astro` の title を「名前 + 役割 + サイト名」形式に変更。文言案を運営者に確認してから実装（案: `谷本和也 | PM/PO・フルスタックエンジニア - byte-lark.com`。Hero の表記 `PM / PO・フルスタックエンジニア` と揃える）
+- [ ] og:title / twitter:title が title と一致（`buildOgMeta()` が title から生成するため実装上は自動。出力で確認）
+- [ ] 他ページの title を壊していない（`yarn build` 後、`dist/` の全 HTML から `<title>` を抽出して一覧確認）
+- [ ] tools/imagegen（cover-image skill）でトップ用 OG 画像（1200x630）を生成し、記事カバーと同系統のトーンにする。候補を提示し運営者が選定
+- [ ] `index.astro` が `BaseLayout` に `ogImage` を渡し、`/` の og:image が専用画像を指す（他ページのフォールバック `og-default.png` は現状維持）
+- [ ] CF preview の HTML で title / og:title / og:image の出力を確認（X の card validator は廃止済み（PHASE1D-009 棚卸し表）。実投稿での見た目確認は 1D-006 の持ち越しと同じ機会に行う）
+- [ ] ローカル スクショ確認（desktop + mobile）（CLAUDE.md §7）
+- [ ] CF preview スクショ確認（branch alias URL）（CLAUDE.md §7）
+- [ ] E2E / CI green 確認（push 後 `scripts/ci-status.sh` で UI Tests=success）（CLAUDE.md §7）
+
+## 技術メモ
+- 想定セッション数: 1（小）
+- 関連ファイル
+  - `src/pages/index.astro:31-33`（title / description）
+  - `src/layouts/BaseLayout.astro:20-22`（ogImage フォールバック）
+  - `src/lib/og.ts`（buildOgMeta。title をそのまま og:title / twitter:title に流す）
+- OG 画像の配置は記事カバーと違い最適化不要（メタ参照のみ）なので `public/` 直下でよい（`og-default.png` と同じ扱い）。ファイル名は `og-home.png` 等、default と区別できる名前にする
+- E2E に title を検証しているテストがあれば追随修正（`tests/e2e/` を grep してから着手）
+
+## 備考
+- 外部レビュー（2026-08-13、Opus によるサイト評価）の指摘 T1 + T2 を 1 PBI に統合したもの。T3〜T7（ご依頼ページ新設 / Career 定量化 / Skills・資格の見せ方 / ブログ方向性）は運営者判断待ちで未起票
+
+## 実装ログ

--- a/docs/pbi/INDEX.md
+++ b/docs/pbi/INDEX.md
@@ -1,11 +1,11 @@
 # PBI Index
 
-最終更新: 2026-08-12（PHASE1E-002 完了）
+最終更新: 2026-08-13（PHASE1E-003 / 004 起票）
 
 ## 次にやること
 
 - 現在地：**Phase 1e（公開後の運用・改善）**。Phase 0 〜 1d は完了（2026-08-08 公開、1d Gate 通過 2026-08-10）
-- 次の PBI：**未起票**。[PHASE1E-002 CI トリガーの整理](20260812-PHASE1E-002-ci-trigger-cleanup.md) は 2026-08-12 に Done（[PHASE1E-001](20260810-PHASE1E-001-postlaunch-housekeeping.md) は 2026-08-11 に Done）。PHASE1D-009 の棚卸し表の持ち越しから、docs 肥大の分割 / セキュリティヘッダの残り / 旧インフラ撤収 / 運営者の実機確認まとめ を起票候補として保留中（2026-08-12 運営者判断待ち）。以後の主活動は記事の書き足しで、カテゴリ別一覧（FR-19）と記事末尾の前後記事リンクは**記事が 10 本に届いた時点**で Phase 1e に追加起票する（現在 3 本）
+- 次の PBI：**[PHASE1E-003 記事 T9（devcontainer で Claude Code 自走）](20260813-PHASE1E-003-post-devcontainer-claude-code.md)**（2026-08-13 起票、運営者指名）。並行枠として [PHASE1E-004 トップの title / OG 画像](20260813-PHASE1E-004-home-title-og-image.md) も同日起票（外部レビュー指摘 T1+T2 採用分。003 の運営者リライト待ちの間に進める）。外部レビュー T3〜T7 と、PHASE1D-009 棚卸し持ち越し分（docs 肥大の分割 / セキュリティヘッダの残り / 旧インフラ撤収 / 運営者の実機確認まとめ）は引き続き運営者判断待ち。以後の主活動は記事の書き足しで、カテゴリ別一覧（FR-19）と記事末尾の前後記事リンクは**記事が 10 本に届いた時点**で Phase 1e に追加起票する（現在 3 本）
 - ブランチ：main から短命ブランチを切り、**最初の push の直後に draft PR**（CI は PR がある状態でのみ走る。README §10.4、PHASE1E-002）。統合ブランチ `feat/phase-1` は 1d Gate で畳んだ（site-plan Decision #31）
 - 直前 Gate の申し送り：[PHASE1D-009](20260808-PHASE1D-009-retrospective-gate.md) の `## 次 Phase への申し送り`
 
@@ -356,6 +356,8 @@ PHASE1D-009 (Phase 1d Retrospective Gate)
 |---|---|---|
 | PHASE1E-001 | [postlaunch-housekeeping](20260810-PHASE1E-001-postlaunch-housekeeping.md) | Done |
 | PHASE1E-002 | [ci-trigger-cleanup](20260812-PHASE1E-002-ci-trigger-cleanup.md) | Done |
+| PHASE1E-003 | [post-devcontainer-claude-code](20260813-PHASE1E-003-post-devcontainer-claude-code.md) | NotStarted |
+| PHASE1E-004 | [home-title-og-image](20260813-PHASE1E-004-home-title-og-image.md) | NotStarted |
 
 ### 起票済み・起票予定
 
@@ -367,6 +369,8 @@ PHASE1D-009 (Phase 1d Retrospective Gate)
   5. `yarn check`（Biome）の対象に `worker/` `scripts/` `tests/` を足す
   6. `src/lib/jsonld.ts` のオリジンを `Astro.site` に追随させる
 - **PHASE1E-002（2026-08-12 起票）**：CI トリガーの整理。`quality.yml` / `ui-tests.yml` が `push` と `pull_request` の両方で発火し、PR が開いている間は同じコミットに `quality` / `e2e` が 2 本ずつ付いていた（PR #39 の head `7bdd828` で実測）。`push` を main だけに絞り、短命ブランチの検査は `pull_request` に一本化する。代わりに最初の push の直後に draft PR を作る運用へ（README §10.4）。出所は PHASE1D-009 の棚卸しではなく 2026-08-12 の運営者指摘
+- **PHASE1E-003（2026-08-13 起票）**：記事 T9「devcontainer で Claude Code を自走させる環境を作った」（tech）。開発環境 3 連作の 2 本目を先行執筆（運営者指名 2026-08-13）
+- **PHASE1E-004（2026-08-13 起票）**：トップページの title / og:title と専用 OG 画像。出所は 2026-08-13 の外部レビュー（Opus によるサイト評価）指摘 T1+T2。同レビューの T3（ご依頼ページ新設）/ T4（Career 定量化）/ T5・T6（Skills・資格の見せ方）/ T7（ブログの営業記事化）は、サイトの目的（site-plan §2「職能リファレンス」）を「営業サイト」へ広げるかの判断と運営者インプットが必要なため未起票・判断待ち
 - **カテゴリ別一覧 + 記事末尾の前後記事リンク（記事 10 本到達時に起票）**：`/blog/tech` `/blog/life` の実 URL 化（FR-19）と、前後リンク（PHASE1D-015 から移管、2026-08-09 運営者判断）。前後の並びは訪問者が見ている一覧と一致させる必要があり、カテゴリが実 URL になれば仕掛けなしで成立する。現在の公開記事は 3 本
 
 ---


### PR DESCRIPTION
## 概要
- PHASE1E-003: 記事バックログ T9（devcontainer で Claude Code を自走させる環境）の PBI 起票（運営者指名 2026-08-13）
- PHASE1E-004: 外部レビュー（Opus によるサイト評価）指摘のうち T1（トップの title 取りこぼし）+ T2（トップ専用 OG 画像）の採用分を 1 PBI に統合して起票
- INDEX.md 同期（次にやること節 / Phase 1e 表 / 起票済み節）。T3〜T7 は運営者判断待ちとして記録

docs のみの変更で配信物に差分なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o3xucGVZW8BCH2cZLpGut