### PR TITLE
fix(monitor): カナリアの title 一致を末尾一致に変更

### DIFF
--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -37,7 +37,8 @@ MONITOR_URL="${MONITOR_URL:-https://byte-lark.com}"
 declare -a PATHS=("/")
 
 # 改ざんカナリア。text/html のページに、この文字列がすべて残っていることを確認する
-declare -a CANARIES=("<title>byte-lark.com</title>" "合同会社バイトラーク")
+# title は「〜 - byte-lark.com」の末尾だけ見る。前半（名前・役割）は変わりうるため完全一致にしない
+declare -a CANARIES=("byte-lark.com</title>" "合同会社バイトラーク")
 
 # 「name=部分文字列」形式。ヘッダ値にその文字列が含まれていることを要求する。
 # HSTS は Cloudflare のゾーン設定で付けているので、外れたら異常として拾う


### PR DESCRIPTION
## 概要
PHASE1E-004 のトップ title 変更で、死活監視のカナリア `<title>byte-lark.com</title>`（完全一致）が不成立になり誤報が発報した。title は末尾のサイト名 `byte-lark.com</title>` のみ照合する形に変更し、今後 title の前半（名前・役割）を変えても誤報にならないようにする。

## 確認
- `bash -n` で構文チェック OK
- 本番 HTML に対し新カナリア 2 本の一致を確認済み

マージ後、Xserver 側で operation-manual §6 の curl による再取得 + 手動一発実行が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bUzd14GrAAYFcx5CLU7gC