### PR TITLE
feat(pbi): PHASE1E-006 セキュリティヘッダの追加（nosniff / Referrer-Policy / X-Frame-Options）

### DIFF
--- a/docs/pbi/20260815-PHASE1E-006-security-headers.md
+++ b/docs/pbi/20260815-PHASE1E-006-security-headers.md
@@ -1,0 +1,39 @@
+# PHASE1E-006: セキュリティヘッダの追加（nosniff / Referrer-Policy / X-Frame-Options）
+
+Status: InProgress
+Started: 2026-08-15
+
+## 誰が
+
+サイト訪問者（とそのブラウザ）が
+
+## 何をできる
+
+全ページで基本のセキュリティヘッダ 3 つ（X-Content-Type-Options / Referrer-Policy / X-Frame-Options）の保護を受けられる。
+
+## なんのために
+
+PHASE1D-007 の実測で本番にセキュリティヘッダが 1 つも無いことが判明し、HSTS のみ同 PBI で追加した。残りは「必要になったら別途起票」としていた分のうち、設定 1 行で済み副作用がほぼ無い 3 つを追加する（運営者決定 2026-08-15）。CSP は Turnstile 等の許可リスト整備が必要で、静的サイトでは費用対効果が悪いため見送り（同決定）。
+
+## 受け入れ条件
+
+- [ ] `public/_headers` に `/*` 向けの 3 ヘッダを追加：`X-Content-Type-Options: nosniff` / `Referrer-Policy: strict-origin-when-cross-origin` / `X-Frame-Options: DENY`
+- [ ] CF preview（branch alias URL）で 3 ヘッダが返ることを curl で実測確認
+- [ ] 既存ヘッダに影響が無いこと（`/_astro/*` の Cache-Control、HSTS）を同実測で確認
+- [ ] ローカル スクショ確認：N/A（ヘッダのみ、表示に変更なし）（CLAUDE.md §7）
+- [ ] CF preview スクショ確認：N/A（同上。curl でのヘッダ実測で代替）（CLAUDE.md §7）
+- [ ] E2E / CI green 確認：`bash scripts/ci-status.sh` で Quality Checks / UI Tests が success（CLAUDE.md §7）
+
+## 技術メモ
+
+- 想定セッション数: 1
+- `public/_headers` は CF Workers 静的アセット配信が読む（PHASE1D-010 で導入。https://developers.cloudflare.com/workers/static-assets/headers/）
+- HSTS は CF ダッシュボード側の設定（PHASE1D-007）なので `_headers` には書かない
+- X-Frame-Options: DENY の根拠：iframe 埋め込みを許す用途が無い（埋め込みたくなったら緩める）
+
+## 備考
+
+- 出所：PHASE1D-007 実装ログ「残る X-Content-Type-Options / Referrer-Policy / CSP は今回の対象外（選択肢として提示済み、必要になったら別途起票）」
+- 同日の運営者決定：Xserver 側 DNS ゾーンは切り戻し保険として残す（確定、判断待ちから除去）。Turnstile 実送信は運営者が実施しメール到達を確認済み
+
+## 実装ログ（着手後に追記、中断時は必須）

--- a/docs/pbi/20260815-PHASE1E-006-security-headers.md
+++ b/docs/pbi/20260815-PHASE1E-006-security-headers.md
@@ -1,7 +1,8 @@
 # PHASE1E-006: セキュリティヘッダの追加（nosniff / Referrer-Policy / X-Frame-Options）
 
-Status: InProgress
+Status: Done
 Started: 2026-08-15
+Completed: 2026-08-15
 
 ## 誰が
 
@@ -17,12 +18,12 @@ PHASE1D-007 の実測で本番にセキュリティヘッダが 1 つも無い�
 
 ## 受け入れ条件
 
-- [ ] `public/_headers` に `/*` 向けの 3 ヘッダを追加：`X-Content-Type-Options: nosniff` / `Referrer-Policy: strict-origin-when-cross-origin` / `X-Frame-Options: DENY`
-- [ ] CF preview（branch alias URL）で 3 ヘッダが返ることを curl で実測確認
-- [ ] 既存ヘッダに影響が無いこと（`/_astro/*` の Cache-Control、HSTS）を同実測で確認
-- [ ] ローカル スクショ確認：N/A（ヘッダのみ、表示に変更なし）（CLAUDE.md §7）
-- [ ] CF preview スクショ確認：N/A（同上。curl でのヘッダ実測で代替）（CLAUDE.md §7）
-- [ ] E2E / CI green 確認：`bash scripts/ci-status.sh` で Quality Checks / UI Tests が success（CLAUDE.md §7）
+- [x] `public/_headers` に `/*` 向けの 3 ヘッダを追加：`X-Content-Type-Options: nosniff` / `Referrer-Policy: strict-origin-when-cross-origin` / `X-Frame-Options: DENY`
+- [x] CF preview（branch alias URL）で 3 ヘッダが返ることを curl で実測確認
+- [x] 既存ヘッダに影響が無いこと（`/_astro/*` の Cache-Control、HSTS）を同実測で確認（HSTS は CF ダッシュボード側設定で `_headers` 変更の影響外。本番 apex はマージ後に確認）
+- [x] ローカル スクショ確認：N/A（ヘッダのみ、表示に変更なし）（CLAUDE.md §7）
+- [x] CF preview スクショ確認：N/A（同上。curl でのヘッダ実測で代替）（CLAUDE.md §7）
+- [x] E2E / CI green 確認：`bash scripts/ci-status.sh` で Quality Checks / UI Tests が success（CLAUDE.md §7）
 
 ## 技術メモ
 
@@ -37,3 +38,18 @@ PHASE1D-007 の実測で本番にセキュリティヘッダが 1 つも無い�
 - 同日の運営者決定：Xserver 側 DNS ゾーンは切り戻し保険として残す（確定、判断待ちから除去）。Turnstile 実送信は運営者が実施しメール到達を確認済み
 
 ## 実装ログ（着手後に追記、中断時は必須）
+
+### 2026-08-15 セッション 1（起票・実施・完了）
+
+#### やったこと
+- `public/_headers` に `/*` ルールを追加（3 ヘッダ + コメント 2 行のみ、計 7 行）
+- CF preview（`chore-1e-006-security-headers-byte-lark.tanimoto-a49.workers.dev`）で curl 実測：
+  - `/`：`x-content-type-options: nosniff` / `referrer-policy: strict-origin-when-cross-origin` / `x-frame-options: DENY` の 3 つとも返る
+  - `/_astro/BaseLayout.D1BVeaQ3.css`：`cache-control: public, max-age=31536000, immutable` 維持 + 3 ヘッダも付与（`/*` と `/_astro/*` のルールはマージされる）
+- CI：Quality Checks / UI Tests(e2e) とも success（実装コミット f9887e1）
+
+#### 学び
+- `_headers` の複数ルールは同一パスに両方マッチするとヘッダがマージされる（`/_astro/*` にも 3 ヘッダが付いた。上書きでなく加算）
+
+#### 想定外
+- なし

--- a/docs/pbi/INDEX.md
+++ b/docs/pbi/INDEX.md
@@ -1,11 +1,11 @@
 # PBI Index
 
-最終更新: 2026-08-15（PHASE1E-006 起票）
+最終更新: 2026-08-15（PHASE1E-006 完了）
 
 ## 次にやること
 
 - 現在地：**Phase 1e（公開後の運用・改善）**。Phase 0 〜 1d は完了（2026-08-08 公開、1d Gate 通過 2026-08-10）
-- 次の PBI：**[PHASE1E-003 記事 T9（devcontainer で Claude Code 自走）](20260813-PHASE1E-003-post-devcontainer-claude-code.md)**（2026-08-13 起票、運営者指名）。並行枠として [PHASE1E-004 トップの title / OG 画像](20260813-PHASE1E-004-home-title-og-image.md) も同日起票（外部レビュー指摘 T1+T2 採用分。003 の運営者リライト待ちの間に進める）。外部レビュー T3〜T7 は不採用で確定（2026-08-13 運営者決定：サイトの目的を「営業サイト」へ広げない）。PHASE1D-009 棚卸し持ち越し分は、docs 肥大の分割を [PHASE1E-005](20260813-PHASE1E-005-docs-slimming.md) として起票・実施済み、Netlify アカウントは削除済み（2026-08-13 運営者報告）。判断待ちだった 3 件は 2026-08-15 に決着：セキュリティヘッダの残りは [PHASE1E-006](20260815-PHASE1E-006-security-headers.md) として起票（CSP は見送り確定）、Xserver 側 DNS ゾーンは切り戻し保険として残すで確定、Turnstile 実送信は運営者がメール到達を確認済み。残る実機確認は SNS カードの実物確認（次の記事告知投稿時）のみ。以後の主活動は記事の書き足しで、カテゴリ別一覧（FR-19）と記事末尾の前後記事リンクは**記事が 10 本に届いた時点**で Phase 1e に追加起票する（現在 3 本）
+- 次の PBI：**[PHASE1E-003 記事 T9（devcontainer で Claude Code 自走）](20260813-PHASE1E-003-post-devcontainer-claude-code.md)**（2026-08-13 起票、運営者指名）。並行枠として [PHASE1E-004 トップの title / OG 画像](20260813-PHASE1E-004-home-title-og-image.md) も同日起票（外部レビュー指摘 T1+T2 採用分。003 の運営者リライト待ちの間に進める）。外部レビュー T3〜T7 は不採用で確定（2026-08-13 運営者決定：サイトの目的を「営業サイト」へ広げない）。PHASE1D-009 棚卸し持ち越し分は、docs 肥大の分割を [PHASE1E-005](20260813-PHASE1E-005-docs-slimming.md) として起票・実施済み、Netlify アカウントは削除済み（2026-08-13 運営者報告）。判断待ちだった 3 件は 2026-08-15 に決着：セキュリティヘッダの残りは [PHASE1E-006](20260815-PHASE1E-006-security-headers.md) として起票・実施済み（CSP は見送り確定）、Xserver 側 DNS ゾーンは切り戻し保険として残すで確定、Turnstile 実送信は運営者がメール到達を確認済み。残る実機確認は SNS カードの実物確認（次の記事告知投稿時）のみ。以後の主活動は記事の書き足しで、カテゴリ別一覧（FR-19）と記事末尾の前後記事リンクは**記事が 10 本に届いた時点**で Phase 1e に追加起票する（現在 3 本）
 - ブランチ：main から短命ブランチを切り、**最初の push の直後に draft PR**（CI は PR がある状態でのみ走る。README §10.4、PHASE1E-002）。統合ブランチ `feat/phase-1` は 1d Gate で畳んだ（site-plan Decision #31）
 - 直前 Gate の申し送り：[PHASE1D-009](20260808-PHASE1D-009-retrospective-gate.md) の `## 次 Phase への申し送り`
 
@@ -359,7 +359,7 @@ PHASE1D-009 (Phase 1d Retrospective Gate)
 | PHASE1E-003 | [post-devcontainer-claude-code](20260813-PHASE1E-003-post-devcontainer-claude-code.md) | NotStarted |
 | PHASE1E-004 | [home-title-og-image](20260813-PHASE1E-004-home-title-og-image.md) | Done |
 | PHASE1E-005 | [docs-slimming](20260813-PHASE1E-005-docs-slimming.md) | Done |
-| PHASE1E-006 | [security-headers](20260815-PHASE1E-006-security-headers.md) | InProgress |
+| PHASE1E-006 | [security-headers](20260815-PHASE1E-006-security-headers.md) | Done |
 
 ### 起票済み・起票予定
 

--- a/docs/pbi/INDEX.md
+++ b/docs/pbi/INDEX.md
@@ -1,11 +1,11 @@
 # PBI Index
 
-最終更新: 2026-08-13（PHASE1E-005 起票・実施）
+最終更新: 2026-08-15（PHASE1E-006 起票）
 
 ## 次にやること
 
 - 現在地：**Phase 1e（公開後の運用・改善）**。Phase 0 〜 1d は完了（2026-08-08 公開、1d Gate 通過 2026-08-10）
-- 次の PBI：**[PHASE1E-003 記事 T9（devcontainer で Claude Code 自走）](20260813-PHASE1E-003-post-devcontainer-claude-code.md)**（2026-08-13 起票、運営者指名）。並行枠として [PHASE1E-004 トップの title / OG 画像](20260813-PHASE1E-004-home-title-og-image.md) も同日起票（外部レビュー指摘 T1+T2 採用分。003 の運営者リライト待ちの間に進める）。外部レビュー T3〜T7 は不採用で確定（2026-08-13 運営者決定：サイトの目的を「営業サイト」へ広げない）。PHASE1D-009 棚卸し持ち越し分は、docs 肥大の分割を [PHASE1E-005](20260813-PHASE1E-005-docs-slimming.md) として起票・実施済み、Netlify アカウントは削除済み（2026-08-13 運営者報告）。残りの判断待ちはセキュリティヘッダの残り / Xserver 側 DNS ゾーンをいつ畳むか / 運営者の実機確認まとめ（Turnstile 実送信 + SNS カード）。以後の主活動は記事の書き足しで、カテゴリ別一覧（FR-19）と記事末尾の前後記事リンクは**記事が 10 本に届いた時点**で Phase 1e に追加起票する（現在 3 本）
+- 次の PBI：**[PHASE1E-003 記事 T9（devcontainer で Claude Code 自走）](20260813-PHASE1E-003-post-devcontainer-claude-code.md)**（2026-08-13 起票、運営者指名）。並行枠として [PHASE1E-004 トップの title / OG 画像](20260813-PHASE1E-004-home-title-og-image.md) も同日起票（外部レビュー指摘 T1+T2 採用分。003 の運営者リライト待ちの間に進める）。外部レビュー T3〜T7 は不採用で確定（2026-08-13 運営者決定：サイトの目的を「営業サイト」へ広げない）。PHASE1D-009 棚卸し持ち越し分は、docs 肥大の分割を [PHASE1E-005](20260813-PHASE1E-005-docs-slimming.md) として起票・実施済み、Netlify アカウントは削除済み（2026-08-13 運営者報告）。判断待ちだった 3 件は 2026-08-15 に決着：セキュリティヘッダの残りは [PHASE1E-006](20260815-PHASE1E-006-security-headers.md) として起票（CSP は見送り確定）、Xserver 側 DNS ゾーンは切り戻し保険として残すで確定、Turnstile 実送信は運営者がメール到達を確認済み。残る実機確認は SNS カードの実物確認（次の記事告知投稿時）のみ。以後の主活動は記事の書き足しで、カテゴリ別一覧（FR-19）と記事末尾の前後記事リンクは**記事が 10 本に届いた時点**で Phase 1e に追加起票する（現在 3 本）
 - ブランチ：main から短命ブランチを切り、**最初の push の直後に draft PR**（CI は PR がある状態でのみ走る。README §10.4、PHASE1E-002）。統合ブランチ `feat/phase-1` は 1d Gate で畳んだ（site-plan Decision #31）
 - 直前 Gate の申し送り：[PHASE1D-009](20260808-PHASE1D-009-retrospective-gate.md) の `## 次 Phase への申し送り`
 
@@ -359,6 +359,7 @@ PHASE1D-009 (Phase 1d Retrospective Gate)
 | PHASE1E-003 | [post-devcontainer-claude-code](20260813-PHASE1E-003-post-devcontainer-claude-code.md) | NotStarted |
 | PHASE1E-004 | [home-title-og-image](20260813-PHASE1E-004-home-title-og-image.md) | Done |
 | PHASE1E-005 | [docs-slimming](20260813-PHASE1E-005-docs-slimming.md) | Done |
+| PHASE1E-006 | [security-headers](20260815-PHASE1E-006-security-headers.md) | InProgress |
 
 ### 起票済み・起票予定
 

--- a/public/_headers
+++ b/public/_headers
@@ -2,6 +2,13 @@
 # public/ に置いたものはそのまま dist/ に入り、wrangler の assets.directory から読まれる。
 # https://developers.cloudflare.com/workers/static-assets/headers/
 
+# 基本のセキュリティヘッダ（PHASE1E-006）。HSTS は CF ダッシュボード側の設定（PHASE1D-007）。
+# X-Frame-Options: DENY は iframe 埋め込みを許す用途が無いため。埋め込みたくなったら緩める。
+/*
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin
+  X-Frame-Options: DENY
+
 # ビルド成果物（CSS / JS / 画像 / フォント）はファイル名に内容のハッシュが入る。
 # 中身が変われば名前も変わるので、ブラウザに 1 年そのまま使わせてよい。
 # 既定は max-age=0, must-revalidate で、ページを移るたびに再検証の往復が入っていた。


### PR DESCRIPTION
PHASE1D-007 で HSTS のみ追加した残りのうち、1 行もの 3 つを `public/_headers` に追加する（CSP は見送り確定、運営者決定 2026-08-15）。

- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `X-Frame-Options: DENY`

検証：CF preview の branch alias URL で curl 実測 + CI green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEgTSLjcCsFXMyuqheHt2y