### PR TITLE
chore(devcontainer): claude install の実行検証 + check-version-refs.sh の bash 3.2 対応

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -92,7 +92,11 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -x
 
 # Install Claude
-RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}
+# npm は optionalDependencies（claude 本体のネイティブバイナリ）の取得失敗を exit 0 で
+# 握りつぶし、スタブが残ったままビルドが成功してしまう（2026-08-15 monotrip.jp で実測）。
+# 実行して検証し、壊れたイメージをビルド時点で落とす
+RUN npm install -g @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
+  && claude --version
 
 # Copy and set up firewall / perms scripts
 # （node に許す sudo はこの固定 2 スクリプトのみ。汎用 sudo は与えない）

--- a/scripts/check-version-refs.sh
+++ b/scripts/check-version-refs.sh
@@ -29,7 +29,7 @@ fi
 
 grep -qF "→ $SP_VER 主な変更" <(head -10 "$SITE_PLAN") \
   || ng "site-plan.md 冒頭「主な変更」注記が $SP_VER になっていない（タイトルと不一致）"
-grep -qF "上書き（v2 → $SP_VER）" "$SITE_PLAN" \
+grep -qF "上書き（v2 → ${SP_VER}）" "$SITE_PLAN" \
   || ng "site-plan.md §6.7 の自己参照が $SP_VER になっていない"
 grep -qF "current: $SP_VER" "$CLAUDE_MD" \
   || ng "CLAUDE.md Related Docs の site-plan 参照が current: $SP_VER になっていない"
@@ -52,4 +52,4 @@ if [ "$fail" -ne 0 ]; then
   echo "バージョン参照の不一致あり。site-plan §14 の表に従って連動更新してから push してください。"
   exit 1
 fi
-echo "OK: バージョン参照は一致（site-plan $SP_VER / PBI README $RM_VER）"
+echo "OK: バージョン参照は一致（site-plan ${SP_VER} / PBI README ${RM_VER}）"


### PR DESCRIPTION
## 概要

devcontainer の Claude インストールに実行検証を足し、あわせて母艦で pre-push フックを止めていた `check-version-refs.sh` の不具合を直す。

## 変更内容

### 1. `.devcontainer/Dockerfile` — claude install に実行検証を追加

`npm install -g @anthropic-ai/claude-code` は optionalDependencies（claude 本体のネイティブバイナリ）の取得に失敗しても exit 0 で握りつぶし、スタブが残ったままイメージのビルドが成功してしまう（2026-08-15 monotrip.jp で実測）。`&& claude --version` を続けて、壊れたイメージをビルド時点で落とす。

### 2. `scripts/check-version-refs.sh` — macOS bash 3.2 での変数展開を修正

`"上書き（v2 → $SP_VER）"` のように変数の直後へ全角括弧が来る箇所が 2 つあった。macOS 標準の bash 3.2 は UTF-8 の多バイト文字を変数名の一部と誤認するため、`SP_VER）` という別名の変数として展開しようとし、`set -u` で `unbound variable` になって exit 1 する。結果、母艦からの push が pre-push フックで常に落ちていた（導入コミット a3bc717 以降ずっと）。CI・コンテナの bash 5 系では再現しないため見逃されていた。`${SP_VER}` / `${RM_VER}` と囲んで解決。

再現:

```
$ bash --version | head -1
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)

$ bash -c 'set -u; V=v3.15; echo "x（$V）y"'
bash: V?: unbound variable
```

## 検証報告

- ローカル確認: `bash scripts/check-version-refs.sh` → `OK: バージョン参照は一致（site-plan v3.15 / PBI README v3.11）` / exit 0。pre-push フック 3 種（typecheck / version-refs / vitest）が全て ✔️ で push 成功
- CF preview 確認: N/A（UI・フロントエンドの変更なし。Dockerfile とシェルスクリプトのみ）
- E2E/CI 確認: この PR の Quality Checks / UI Tests の結果を `scripts/ci-status.sh` で確認する
- 未検証項目: `.devcontainer/Dockerfile` の実ビルドは未実行（母艦サンドボックスで docker build 不可）。次回 `ccd --rebuild` 時に `claude --version` が通ることで確認される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfaJswt8B96tG5QE7YEiaU
