### PR TITLE
chore(devcontainer): firewall 許可先に zenn.dev を追加

### DIFF
--- a/.devcontainer/allowed-domains.conf
+++ b/.devcontainer/allowed-domains.conf
@@ -32,6 +32,10 @@ byte-lark.com
 docs.astro.build
 developers.cloudflare.com
 
+# 技術記事の参照（本文取得のみ。CF 配下で起動時解決 IP が回転し得る
+# — 本ファイル冒頭の注意。読めなくなったら ccd 再起動で再解決する）
+zenn.dev
+
 # サイトが読み込む解析スクリプト（E2E 実行時のアクセス先）
 plausible.io
 


### PR DESCRIPTION
## 背景

コンテナから技術記事（zenn.dev）を参照できず、記事本文の取得が firewall で止まる。

## 変更

`.devcontainer/allowed-domains.conf` に `zenn.dev` を 1 行追加。

## 注意

zenn.dev は Cloudflare 配下のため、ドメイン行方式（起動時に解決した IP だけを許可）では IP 回転で読めなくなることがある。その場合は `ccd` で入り直して再解決する。この注意はファイル冒頭にも書かれている既知の制約で、本 PR で新たに増える弱点ではない。

## 検証

- ローカル確認：N/A（UI 変更なし。firewall 設定ファイルのみ）
- CF preview 確認：N/A（サイト出力に影響しない）
- E2E/CI 確認：本 PR の UI Tests / Quality Checks で確認する
- 実効性の確認：マージ後にコンテナを入り直し、zenn.dev への疎通で確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EX6GXNRhBHxYMF6RyCNJ1x