### PR TITLE
chore(devcontainer): firewall 許可先に qiita.com を追加

### DIFF
--- a/.devcontainer/allowed-domains.conf
+++ b/.devcontainer/allowed-domains.conf
@@ -32,9 +32,10 @@ byte-lark.com
 docs.astro.build
 developers.cloudflare.com
 
-# 技術記事の参照（本文取得のみ。CF 配下で起動時解決 IP が回転し得る
-# — 本ファイル冒頭の注意。読めなくなったら ccd 再起動で再解決する）
+# 技術記事の参照（本文取得のみ）。zenn.dev は Cloudflare、qiita.com は CloudFront 配下で
+# 起動時解決 IP が回転し得る（本ファイル冒頭の注意）。読めなくなったら ccd 再起動で再解決する
 zenn.dev
+qiita.com
 
 # サイトが読み込む解析スクリプト（E2E 実行時のアクセス先）
 plausible.io


### PR DESCRIPTION
## 背景

技術記事の参照先として zenn.dev を許可した（#54）。同じ用途で Qiita も読めるようにする。

## 変更

`.devcontainer/allowed-domains.conf` に `qiita.com` を追加。あわせて、zenn.dev / qiita.com が別々の CDN 配下であることをコメントに明記した。

- zenn.dev → Cloudflare（`104.26.14.203` 他）
- qiita.com → CloudFront（`99.84.48.19` 他）

いずれもドメイン行方式（起動時に解決した IP だけを許可）なので、IP 回転で読めなくなることがある。その場合は `ccd` で入り直して再解決する。ファイル冒頭に既記載の制約で、本 PR で新たに増える弱点ではない。

## 検証

- ローカル確認：N/A（UI 変更なし。firewall 設定ファイルのみ）
- CF preview 確認：N/A（サイト出力に影響しない）
- E2E/CI 確認：本 PR の UI Tests / Quality Checks で確認する
- A レコードの解決：`dig +noall +answer A` で両ドメインとも IPv4 が返ることを確認済み（init-firewall.sh は A レコードのみ参照するため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EX6GXNRhBHxYMF6RyCNJ1x