### PR TITLE
chore(claude): UserPromptSubmit に検証規律ダイジェスト hook を追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,6 +52,15 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "awk '/^<!-- hook-digest:start -->/{f=1;next} /^<!-- hook-digest:end -->/{f=0} f' \"$HOME/.claude/output-styles/concise-ja.md\"",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "Notification": [


### PR DESCRIPTION
## Summary
- `.claude/settings.json` の UserPromptSubmit に、正本 `~/.claude/output-styles/concise-ja.md` のマーカー節（毎ターン注入ダイジェスト）を awk 抽出して注入する hook を追加
- 正本を直せば注入も自動で追従する（二重管理なし）。正本が無い環境では無出力で安全に退化
- 経緯・設計判断は `docs/handoff-20260815-response-discipline.md` §6（未追跡の作業メモ）

## Test plan
- [x] 母艦セッションで毎ターン注入を実測（2026-08-16 追加当日から稼働、正本編集の即時追従も確認済み）
- [ ] Quality Checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PfdrA22cWxGWDwH9w8jrfk