### PR TITLE
docs: gh CLI の sandbox 記述を実態に更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,9 @@ Stop hook（PBI Done 宣言の検証ゲート監査）でレスポンスがブ�
 ## Sandbox 制約
 - git 操作は worktree 不使用。公開後は main から短命ブランチを切って作業し、PR でマージする（main は ruleset で保護され直接 push できない。詳細: docs/pbi/README.md §10.3-10.6）
 - `yarn up` / `yarn add` 等レジストリアクセスが必要なコマンドは、Bash ツールでも `!` プレフィックスでも DNS 解決が失敗する。運営者に別ターミナル（Claude Code 外）での実行を依頼する
-- E2E スイート（Playwright test runner）は Bash サンドボックスで Chromium 起動不可（Mach port 権限拒否で即 FATAL）。ローカルで `yarn test:e2e` を叩かず、draft PR を作って CI（`.github/workflows/ui-tests.yml`、ubuntu コンテナ）で検証し `scripts/ci-status.sh` で合否を読む（gh CLI は sandbox 内で TLS/keychain により不可、curl は可）。UI スクショ確認は MCP Playwright で行う
-- 上記の yarn / E2E / gh 制約は母艦（macOS Seatbelt sandbox）のもの。devcontainer 内のセッションには適用されない（次節）
+- E2E スイート（Playwright test runner）は Bash サンドボックスで Chromium 起動不可（Mach port 権限拒否で即 FATAL）。ローカルで `yarn test:e2e` を叩かず、draft PR を作って CI（`.github/workflows/ui-tests.yml`、ubuntu コンテナ）で検証し `scripts/ci-status.sh` で合否を読む。UI スクショ確認は MCP Playwright で行う
+- gh CLI は使える：運営者のユーザー設定（dotfiles の `sandbox.excludedCommands`、2026-07-04 導入）で gh のみ sandbox 外実行になるため。環境設定依存なので、gh が失敗する環境では無認証 curl の `scripts/ci-status.sh` で代替する
+- 上記の yarn / E2E 制約は母艦（macOS Seatbelt sandbox）のもの。devcontainer 内のセッションには適用されない（次節）
 
 ## Devcontainer 自走環境
 - `.devcontainer/` は Claude Code をコンテナ内で全権限自走させる環境（PHASE1B-016 導入。設計・実施手順: docs/devcontainer-plan.md）。今いる環境の見分け方：作業ディレクトリが `/workspace` ならコンテナ内、`/Users/kazuya/...` なら母艦

--- a/docs/devcontainer-plan.md
+++ b/docs/devcontainer-plan.md
@@ -13,7 +13,7 @@
 
 macOS の Bash sandbox（Seatbelt）上で Claude Code を動かしていると：
 
-- 実行できないコマンドが多い（`yarn add` / `yarn up` は DNS 解決失敗、E2E の Chromium は Mach port 拒否で起動不可、`docker` は非互換、`gh` は TLS/keychain 不可）
+- 実行できないコマンドが多い（`yarn add` / `yarn up` は DNS 解決失敗、E2E の Chromium は Mach port 拒否で起動不可、`docker` は非互換、`gh` は TLS/keychain 不可 ※gh のみ 2026-07-04 に dotfiles の sandbox 除外設定で解消済み、他は現存）
 - 承認プロンプトが多く、放置自走（無人実行）ができない
 
 ### 1.2 過去に却下した案

--- a/scripts/ci-status.sh
+++ b/scripts/ci-status.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # CI（GitHub Actions）の状況を無認証 REST API で取得する。
-# 本リポジトリは public なのでトークン不要。Bash サンドボックス内では gh CLI が
-# TLS/keychain で失敗するが curl は通るため、curl + jq で代替する。
+# 本リポジトリは public なのでトークン不要。gh CLI も使える（dotfiles の
+# sandbox.excludedCommands で sandbox 外実行・2026-07-04〜）が、本スクリプトは
+# 環境設定に依存しない無認証 curl + jq で完結させている。
 #
 # 使い方:
 #   bash scripts/ci-status.sh [branch]   # branch 省略時は現在のブランチ


### PR DESCRIPTION
## 概要

「gh CLI は sandbox 内で TLS/keychain により不可」という記述 3 箇所を実態に更新する。

- 実態：dotfiles の `sandbox.excludedCommands`（2026-07-04 導入、dotfiles e6e27ef）で gh のみ sandbox 外実行になり使用可（PR #58 で create/ready/merge の動作を実測）
- CLAUDE.md：Sandbox 制約節を「gh は使える（環境設定依存、失敗時は curl の ci-status.sh で代替）」に更新、隣接行の gh 列挙も除去
- scripts/ci-status.sh：ヘッダコメントを「無認証 curl で完結させている」理由説明に更新（スクリプト本体は変更なし）
- docs/devcontainer-plan.md：制約列挙に「gh のみ解消済み」の注記を追加（導入動機の記録は残す）
- 決定ログ（Decision #27）と PBI 実装ログ 3 件は時点記録のため据え置き

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYAWsCkEbzQ8QZgmJYhvYC